### PR TITLE
Selections and Producers

### DIFF
--- a/alphatwirl_interface/__init__.py
+++ b/alphatwirl_interface/__init__.py
@@ -1,7 +1,9 @@
 from .tree import Tree
 from .table import Table
+from .selection import Selection
 
 __all__ = [
     'Tree',
     'Table',
+    'Selection',
 ]

--- a/alphatwirl_interface/cut_flows.py
+++ b/alphatwirl_interface/cut_flows.py
@@ -1,15 +1,35 @@
 import alphatwirl
 
-def cut_flow_with_counter(cut_flow, cut_flow_summary_filename):
-    eventSelection = alphatwirl.selection.build_selection(
-        path_cfg = cut_flow,
-        AllClass = alphatwirl.selection.modules.AllwCount,
-        AnyClass = alphatwirl.selection.modules.AnywCount,
-        NotClass = alphatwirl.selection.modules.NotwCount
+
+def _build_selection(cut_flow):
+    return alphatwirl.selection.build_selection(
+        path_cfg=cut_flow,
+        AllClass=alphatwirl.selection.modules.AllwCount,
+        AnyClass=alphatwirl.selection.modules.AnywCount,
+        NotClass=alphatwirl.selection.modules.NotwCount
     )
+
+
+def _file_collector(cut_flow_summary_filename):
     resultsCombinationMethod = alphatwirl.collector.ToTupleListWithDatasetColumn(
-        summaryColumnNames = ('depth', 'class', 'name', 'pass', 'total')
+        summaryColumnNames=('depth', 'class', 'name', 'pass', 'total')
     )
-    deliveryMethod = alphatwirl.collector.WriteListToFile(cut_flow_summary_filename)
-    collector = alphatwirl.loop.Collector(resultsCombinationMethod, deliveryMethod)
+    deliveryMethod = alphatwirl.collector.WriteListToFile(
+        cut_flow_summary_filename)
+    collector = alphatwirl.loop.Collector(
+        resultsCombinationMethod, deliveryMethod)
+    return collector
+
+
+def cut_flow_with_counter(cut_flow, cut_flow_summary_filename):
+    eventSelection = _build_selection(cut_flow)
+    collector = _file_collector(cut_flow_summary_filename)
+
+    return [(eventSelection, collector)]
+
+
+def cut_flow(cut_flow):
+    eventSelection = _build_selection(cut_flow)
+    collector = alphatwirl.loop.NullCollector()
+
     return [(eventSelection, collector)]

--- a/alphatwirl_interface/cut_flows.py
+++ b/alphatwirl_interface/cut_flows.py
@@ -1,5 +1,5 @@
 import alphatwirl
-
+from alphatwirl_interface.completions import to_null_collector_pairs
 
 def _build_selection(cut_flow):
     return alphatwirl.selection.build_selection(
@@ -30,6 +30,4 @@ def cut_flow_with_counter(cut_flow, cut_flow_summary_filename):
 
 def cut_flow(cut_flow):
     eventSelection = _build_selection(cut_flow)
-    collector = alphatwirl.loop.NullCollector()
-
-    return [(eventSelection, collector)]
+    return to_null_collector_pairs([eventSelection])

--- a/alphatwirl_interface/producers/__init__.py
+++ b/alphatwirl_interface/producers/__init__.py
@@ -1,5 +1,9 @@
 from .invariantMass import InvariantMass
+from .functions import NewFromFunction, TransverseMomentum, Divide
 
 __all__ = [
     'InvariantMass',
+    'NewFromFunction',
+    'TransverseMomentum',
+    'Divide',
 ]

--- a/alphatwirl_interface/producers/__init__.py
+++ b/alphatwirl_interface/producers/__init__.py
@@ -1,0 +1,5 @@
+from .invariantMass import InvariantMass
+
+__all__ = [
+    'InvariantMass',
+]

--- a/alphatwirl_interface/producers/basic.py
+++ b/alphatwirl_interface/producers/basic.py
@@ -12,6 +12,16 @@ class BasicProducer(object):
             self.__class__.__name__,
         )
 
+    def _format_attributes(self, attributes):
+        values = [getattr(self, attr) for attr in attributes]
+        template = '{} = {!r}'
+        formattedStrings = []
+        for attr, value in zip(attributes, values):
+            formattedString = template.format(attr, value)
+            formattedStrings.append(formattedString)
+
+        return ', '.join(formattedStrings)
+
     def _attach_to_obj(self, obj):
         setattr(obj, self.outputName, self.value)
 

--- a/alphatwirl_interface/producers/basic.py
+++ b/alphatwirl_interface/producers/basic.py
@@ -1,0 +1,30 @@
+from alphatwirl_interface.completions import complete, to_null_collector_pairs
+
+
+class BasicProducer(object):
+
+    def __init__(self, outputName):
+        self.outputName = outputName
+        self.value = []
+
+    def __repr__(self):
+        return '{}()'.format(
+            self.__class__.__name__,
+        )
+
+    def _attach_to_obj(self, obj):
+        setattr(obj, self.outputName, self.value)
+
+    def _value(self, obj):
+        return [42]
+
+    def begin(self, obj):
+        self.value = []
+        self._attach_to_obj(obj)
+
+    def event(self, obj):
+        self._attach_to_obj(obj)
+        self.value[:] = self._value(obj)
+
+    def as_tuple(self):
+        return to_null_collector_pairs([self])[0]

--- a/alphatwirl_interface/producers/functions.py
+++ b/alphatwirl_interface/producers/functions.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from .basic import BasicProducer
+
+
+class NewFromFunction(BasicProducer):
+
+    def __init__(self, outputName, inputs, function):
+        super(NewFromFunction, self).__init__(outputName)
+        self.inputs = inputs
+        self.function = function
+
+    def _value(self, obj):
+        return self.function(
+            *[np.array(getattr(obj, n)) for n in self.inputs]
+        )
+
+    def __repr__(self):
+        attributes = ['outputName', 'inputs', 'function']
+        formattedAttrs = super(
+            NewFromFunction, self)._format_attributes(attributes)
+
+        return '{}({})'.format(
+            self.__class__.__name__,
+            formattedAttrs,
+        )
+
+
+class Divide(NewFromFunction):
+    def __init__(self, outputName, inputs):
+        super(self.__class__, self).__init__(outputName, inputs, np.divide)
+
+class TransverseMomentum(NewFromFunction):
+    def __init__(self, outputName, inputs):
+        super(self.__class__, self).__init__(
+            outputName,
+            inputs,
+            function = lambda x, y: np.sqrt(np.square(x) + np.square(y))
+        )

--- a/alphatwirl_interface/producers/invariantMass.py
+++ b/alphatwirl_interface/producers/invariantMass.py
@@ -33,11 +33,13 @@ class InvariantMass(BasicProducer):
 
         self.v1 = []
         self.v2 = []
+        self.v = []
 
     def _value(self, obj):
         self.v1[:] = list(_extract_values(obj, self.input1))
         self.v2[:] = list(_extract_values(obj, self.input2))
+        self.v[:] = np.add(self.v1, self.v2)
 
-        energy = self.v1[0] * self.v2[0]
-        momentum = np.dot(self.v1[1:], self.v2[1:])
-        return [np.sqrt(energy - momentum)]
+        energySquared = pow(self.v[0], 2)
+        momentumSquared = np.dot(self.v[1:], self.v[1:])
+        return [np.sqrt(energySquared - momentumSquared)]

--- a/alphatwirl_interface/producers/invariantMass.py
+++ b/alphatwirl_interface/producers/invariantMass.py
@@ -1,0 +1,43 @@
+import numpy as np
+import re
+from .basic import BasicProducer
+
+
+def _extract_index(name):
+    token = '\[\d+\]'
+    match = re.search(token, name)
+    if match:
+        substr = match.group(0)
+        index = int(substr.strip('[]'))
+        newName = name.replace(substr, '')
+
+        return newName, index
+    return name, None
+
+def _extract_values(obj, namesAndIndices):
+    for (name, index) in namesAndIndices:
+        if index is not None:
+            yield getattr(obj, name)[index]
+        else:
+            yield getattr(obj, name)
+
+class InvariantMass(BasicProducer):
+
+    def __init__(self, outputName, fourMomentum1, fourMomentum2):
+        '''
+            fourMomentum = [energy, px, py, pz]
+        '''
+        super(InvariantMass, self).__init__(outputName)
+        self.input1 = [_extract_index(x) for x in fourMomentum1]
+        self.input2 = [_extract_index(x) for x in fourMomentum2]
+
+        self.v1 = []
+        self.v2 = []
+
+    def _value(self, obj):
+        self.v1[:] = list(_extract_values(obj, self.input1))
+        self.v2[:] = list(_extract_values(obj, self.input2))
+
+        energy = self.v1[0] * self.v2[0]
+        momentum = np.dot(self.v1[1:], self.v2[1:])
+        return [np.sqrt(energy - momentum)]

--- a/alphatwirl_interface/selection.py
+++ b/alphatwirl_interface/selection.py
@@ -17,7 +17,21 @@ Out:
 from collections import Sequence
 from alphatwirl_interface.cut_flows import cut_flow, cut_flow_with_counter
 import six
+import re
 
+VARIABLE_NAME_PATTERN = re.compile('\s?([A-Za-z][A-Za-z0-9_]+)\[?')
+
+def _step_to_lambda_string(step):
+    token = 'ev'
+    match = VARIABLE_NAME_PATTERN.findall(step)
+    result = step
+    if match:
+        for m in match:
+            newName = token + '.' + m
+            if not newName in result:
+                result = result.replace(m, newName)
+
+    return 'ev: {0}'.format(result)
 
 class Selection(object):
 
@@ -61,7 +75,8 @@ class Selection(object):
                     if isinstance(c, dict):
                         at_cuts.append(self._convert_to_alphatwirl(c))
                     else:
-                        at_cuts.append('ev: ev.{0}'.format(c))
+                        at_cuts.append(_step_to_lambda_string(c))
                 at_dict[k] = tuple(at_cuts)
+
 
         return at_dict

--- a/alphatwirl_interface/selection.py
+++ b/alphatwirl_interface/selection.py
@@ -1,0 +1,67 @@
+'''
+In:
+    Selection.append('NMuon == 2')
+    Selection.append(['NJet == 2', 'NJet == 3'], require=Selection.Any)
+
+Out:
+    event_selection = dict(
+        All = (
+            'ev : ev.NMuon == 2',
+            Any = (
+                'ev : ev.NJet == 2',
+                'ev : ev.NJet == 3',
+            )
+        )
+    )
+'''
+from collections import Sequence
+from alphatwirl_interface.cut_flows import cut_flow, cut_flow_with_counter
+import six
+
+
+class Selection(object):
+
+    def __init__(self, steps):
+        self.outputFile = ''
+        self.steps = steps
+
+    def set_monitoring_file(self, fileName):
+        self.outputFile = fileName
+
+    def as_list(self):
+        return [self.as_tuple()]
+
+    def as_tuple(self):
+        return self._get_reader_collector_pair()
+
+    def _get_reader_collector_pair(self):
+        rc_pair = None
+        at_selection = self._convert_to_alphatwirl()
+        if self.outputFile:
+            rc_pair = cut_flow_with_counter(
+                at_selection, self.outputFile,
+            )
+        else:
+            rc_pair = cut_flow(at_selection)
+        return rc_pair[0]
+
+    def _convert_to_alphatwirl(self, ati_dict=None):
+        at_dict = {}
+        if ati_dict is None:
+            ati_dict = self.steps
+
+        for k, cuts in ati_dict.items():
+            if isinstance(cuts, dict):
+                at_dict[k] = self._convert_to_alphatwirl(cuts)
+            else:
+                if isinstance(cuts, six.string_types):
+                    cuts = [cuts]
+                at_cuts = []
+                for c in cuts:
+                    if isinstance(c, dict):
+                        at_cuts.append(self._convert_to_alphatwirl(c))
+                    else:
+                        at_cuts.append('ev: ev.{0}'.format(c))
+                at_dict[k] = tuple(at_cuts)
+
+        return at_dict

--- a/alphatwirl_interface/table.py
+++ b/alphatwirl_interface/table.py
@@ -42,3 +42,20 @@ class Table(collections.MutableMapping):
 
     def copy(self):
         return Table(**self.store)
+
+    def __repr__(self):
+        result = []
+        for k, v in self.store.items():
+            result.append('{0}={1}'.format(k, v))
+        title = '{}(): '.format(self.__class__.__name__)
+        return title + ', '.join(result)
+
+    @property
+    def outputColumns(self):
+        output = []
+        if 'valOutColumnNames' in self.store:
+            output.extend(self.store['valOutColumnNames'])
+        if 'keyOutColumnNames' in self.store:
+            output.extend(self.store['keyOutColumnNames'])
+        # only return unique columns
+        return list(set(output))

--- a/alphatwirl_interface/table.py
+++ b/alphatwirl_interface/table.py
@@ -52,10 +52,12 @@ class Table(collections.MutableMapping):
 
     @property
     def outputColumns(self):
+        # needs to preserve order
         output = []
         if 'valOutColumnNames' in self.store:
             output.extend(self.store['valOutColumnNames'])
         if 'keyOutColumnNames' in self.store:
-            output.extend(self.store['keyOutColumnNames'])
-        # only return unique columns
-        return list(set(output))
+            for k in self.store['keyOutColumnNames']:
+                if not k in output:
+                    output.append(k)
+        return output

--- a/alphatwirl_interface/tree.py
+++ b/alphatwirl_interface/tree.py
@@ -2,6 +2,7 @@ import alphatwirl as at
 from alphatwirl_interface.completions import to_null_collector_pairs
 from copy import deepcopy
 
+
 class EventBuilder(object):
 
     def __init__(self, tree, max_events=-1):
@@ -87,28 +88,30 @@ def _complement_tblcfg_with_default(tblcfg, default_cfg):
 
 def build_counter_collector_pair(tblcfg):
     keyValComposer = at.summary.KeyValueComposer(
-        keyAttrNames=tblcfg['keyAttrNames'],
         binnings=tblcfg['binnings'],
         keyIndices=tblcfg['keyIndices'],
         valAttrNames=tblcfg['valAttrNames'],
-        valIndices=tblcfg['valIndices']
+        valIndices=tblcfg['valIndices'],
     )
-    nextKeyComposer = at.summary.NextKeyComposer(
-        tblcfg['binnings']) if tblcfg['binnings'] is not None else None
+
+    nextKeyComposer = None
+    if tblcfg['binnings'] is not None:
+        nextKeyComposer = at.summary.NextKeyComposer(tblcfg['binnings'])
+
     summarizer = at.summary.Summarizer(
-        Summary=tblcfg['summaryClass']
+        Summary=tblcfg['summaryClass'],
     )
     reader = at.summary.Reader(
         keyValComposer=keyValComposer,
         summarizer=summarizer,
         nextKeyComposer=nextKeyComposer,
         weightCalculator=tblcfg['weight'],
-        nevents=tblcfg['nevents']
+        nevents=tblcfg['nevents'],
     )
     resultsCombinationMethod = at.collector.ToDataFrame(
-        summaryColumnNames=tblcfg[
-            'keyOutColumnNames'] + tblcfg['valOutColumnNames']
+        summaryColumnNames=tblcfg.outputColumns,
     )
+
     deliveryMethod = None
     collector = at.loop.Collector(
         resultsCombinationMethod, deliveryMethod)

--- a/alphatwirl_interface/tree.py
+++ b/alphatwirl_interface/tree.py
@@ -1,5 +1,5 @@
 import alphatwirl as at
-
+from alphatwirl_interface.completions import to_null_collector_pairs
 
 class EventBuilder(object):
 
@@ -36,15 +36,12 @@ class Tree(object):
             ', '.join(['{} = {!r}'.format(n, v) for n, v in name_value_pairs]),
         )
 
-    def summarize(self, tblcfg, max_events=-1, selection=None):
-        reader_collector_pairs = []
+    def summarize(self, tblcfg, max_events=-1, modules=[]):
         default_cfg = dict(
             outFile=False,
         )
 
-        if selection is not None:
-            reader_collector_pairs.append(selection.as_tuple())
-
+        reader_collector_pairs = modules
         tblcfg = self._complement_tblcfg_with_default(tblcfg, default_cfg)
 
         tableConfigCompleter = at.configure.TableConfigCompleter(
@@ -68,7 +65,7 @@ class Tree(object):
 
         return collector.collect(((None, (reader, )), ))
 
-    def scan(self, tblcfg, max_events=10, selection=None):
+    def scan(self, tblcfg, max_events=10, modules=[]):
 
         default_cfg = dict(
             keyAttrNames=(),
@@ -79,7 +76,7 @@ class Tree(object):
         return self.summarize(
             tblcfg,
             max_events=max_events,
-            selection=selection,
+            modules=modules,
         )
 
     def _complement_tblcfg_with_default(self, tblcfg, default_cfg):

--- a/test/test_selection.py
+++ b/test/test_selection.py
@@ -30,3 +30,22 @@ def test_conversion():
     )
 
     assert_equals(selection._convert_to_alphatwirl(), expected)
+
+def test_conversion_with_more_than_one():
+    selection = Selection(
+        dict(
+            All=(
+                'Muon_E[0] > 2 * Muon_Pt[1]',
+                'Muon_Charge[0] == Muon_Charge[0]',
+            )
+        )
+    )
+
+    expected = dict(
+        All=(
+            'ev: ev.Muon_E[0] > 2 * ev.Muon_Pt[1]',
+            'ev: ev.Muon_Charge[0] == ev.Muon_Charge[0]',
+        )
+    )
+
+    assert_equals(selection._convert_to_alphatwirl(), expected)

--- a/test/test_selection.py
+++ b/test/test_selection.py
@@ -1,0 +1,32 @@
+from alphatwirl_interface import Selection
+from nose.tools import assert_equals
+
+
+def test_conversion():
+    selection = Selection(
+        dict(
+            All=(
+                'NMuon == 2',
+                dict(
+                    Any=(
+                        'NJet == 2',
+                        'NJet == 3',
+                    )
+                )
+            )
+        )
+    )
+
+    expected = dict(
+        All=(
+            'ev: ev.NMuon == 2',
+            dict(
+                Any=(
+                    'ev: ev.NJet == 2',
+                    'ev: ev.NJet == 3',
+                )
+            )
+        )
+    )
+
+    assert_equals(selection._convert_to_alphatwirl(), expected)

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -1,0 +1,25 @@
+import alphatwirl as at
+from alphatwirl_interface import Table
+from alphatwirl_interface.tree import _complement_tblcfg_with_default
+from nose.tools import assert_equal
+
+
+def test_vanishing_attribute_names():
+    '''
+        Unit test for a bug: disappearing valAttrNames
+    '''
+    columns = ('NJet', 'di_muon_mass')
+    tables = [
+        Table(
+            input_values=columns,
+        ),
+    ]
+
+    default_cfg = dict(
+        keyAttrNames=(),
+        sort=False,
+        summaryClass=at.summary.Scan,
+        outFile=False,
+    )
+    tables = _complement_tblcfg_with_default(tables, default_cfg)
+    assert_equal(tables[0]['valAttrNames'], columns)


### PR DESCRIPTION
For this PR I am planning to
 - [x] Add new selection interface
 - [x] Add InvariantMass producer

The current implementation is not yet fully working, even if I use an empty selection:
```python
selection = Selection(
        dict(
            All=()
        )
    )

selection.set_monitoring_file('test.txt')
```
The code:
```python
dataframes = tree.scan(tblcfg=tables, max_events=50, selection=selection)

    for df in dataframes:
        print df
        print df.to_string(index=False)
```
Produces the error
```
[('component', 'depth', 'class', 'name', 'pass', 'total')]
Traceback (most recent call last):
  File "run.py", line 57, in <module>
    print df.to_string(index=False)
AttributeError: 'list' object has no attribute 'to_string'
```

If somebody can think of an easy unit test for this problem that does not use data, please let me know.