### PR TITLE
Exclude the workArea for parallel jobs (needs AlphaTwirl PR 13)

### DIFF
--- a/alphatwirl_interface/heppy/parallel.py
+++ b/alphatwirl_interface/heppy/parallel.py
@@ -66,7 +66,8 @@ def build_parallel_dropbox(parallel_mode, quiet, user_modules, htcondor_job_desc
         dispatcher = alphatwirl.concurrently.SubprocessRunner()
     workingArea = alphatwirl.concurrently.WorkingArea(
         dir = tmpdir,
-        python_modules = list(user_modules)
+        python_modules = list(user_modules),
+        exclusions = ["*{}*".format(tmpdir)]
     )
     dropbox = alphatwirl.concurrently.TaskPackageDropbox(
         workingArea = workingArea,


### PR DESCRIPTION
Makes use of changes to AlphaTwirl from https://github.com/alphatwirl/alphatwirl/pull/13 to exclude the output area of previous jobs from being bundled into the tarball of new jobs if the work area is within the python directories of the analysis code.  That should generally be avoided, but this edit makes things a bit safer.